### PR TITLE
Feature consolidate news routes

### DIFF
--- a/server/api/news.js
+++ b/server/api/news.js
@@ -12,6 +12,7 @@ router.get('/who', (req, res) => {
   });
 });
 
+/* CDC news data request */
 router.get('/cdc', (req, res) => {
   News.retrieveCdcNews((err, data) => {
     if (err) 
@@ -19,5 +20,15 @@ router.get('/cdc', (req, res) => {
     return res.json(data);
   });
 });
+
+/* news data request */
+router.get('/', (req, res) => {
+  News.retrieveNews((err, data) => {
+    if (err) 
+      return res.json(err);
+    return res.json(data);
+  });
+});
+
 
 module.exports = router;

--- a/server/api/news.js
+++ b/server/api/news.js
@@ -3,25 +3,9 @@ var News = require('../models/news');
 
 var router = express.Router();
 
-/* WHO news data request */
-router.get('/who', (req, res) => {
-  News.retrieveWhoNews((err, data) => {
-    if (err) 
-      return res.json(err);
-    return res.json(data);
-  });
-});
-
-/* CDC news data request */
-router.get('/cdc', (req, res) => {
-  News.retrieveCdcNews((err, data) => {
-    if (err) 
-      return res.json(err);
-    return res.json(data);
-  });
-});
-
-/* news data request */
+/* news data request should go to /api/news 
+returns all articles from who and cdc rss feeds in sorted order from most recent
+to least recent */
 router.get('/', (req, res) => {
   News.retrieveNews((err, data) => {
     if (err) 

--- a/server/models/news.js
+++ b/server/models/news.js
@@ -1,33 +1,56 @@
 const Parser = require('rss-parser');
+
+
 const parser = new Parser();
 
-class News {
-  static async retrieveWhoNews(callback) {
 
-    try{
-      let feed = await parser.parseURL('https://www.who.int/rss-feeds/news-english.xml');
-      console.log(feed.title);
-      let filtered_items = feed.items.filter(function(item) {
+class News {
+  /* Combine resonses from WHO and CDC into a single response converts from xml to json 
+  calls the two rss feeds and returns only the fields we use: title->name, link->url, date converted
+  to a date rather than a string and sorted in desc order, and source which we add, as well as content 
+  which can serve as an abstract */
+  static async retrieveNews(callback) {
+    try {
+
+      let who_feed = await parser.parseURL('https://www.who.int/rss-feeds/news-english.xml');
+      let filtered_who = who_feed.items.filter(function(item) {
         return item.content.includes('COVID');
       });
-      callback(filtered_items);
+
+      let mapped_who = filtered_who.map(function(item) {
+        return {
+          "url": item.link,
+          "name": item.title,
+          "source": "World Health Organization",
+          "date": new Date(item.pubDate),
+          "content": item.content
+        };
+      });
+
+      let cdc_feed = await parser.parseURL('https://tools.cdc.gov/api/v2/resources/media/403372.rss');
+      let mapped_cdc = cdc_feed.items.map(function(item) {
+        return {
+          "url": item.link,
+          "name": item.title,
+          "source": "Centers for Disease Control",
+          "date": new Date(item.pubDate),
+          "content": item.content
+        };
+      });
+
+      let combined = [...mapped_who, ...mapped_cdc];
+  
+      let sorted = combined.sort(function(a,b){
+         return b.date - a.date;
+      });
+
+      callback(sorted);
     }
-    catch (error){
-       console.error(error);
-    }
-    return 
-  }
-  static async retrieveCdcNews(callback) {
-    try{
-      let feed = await parser.parseURL('https://tools.cdc.gov/api/v2/resources/media/403372.rss');
-      console.log(feed.title);
-      callback(feed.items);
-    }
-    catch (error){
-       console.error(error);
-    }
-    return 
-  }
+    catch(err){
+     console.error(err);
+   }
+   return
+ }
 
 }
 


### PR DESCRIPTION
Going from 2 news endpoints to one, also cleans up the dates so they are sortable and actually treated like dates, converts the field names in the rss feeds to the field names we are using in our database, and limits what we pass from the rss feeds to our api to just what we will use url, name, date, source, content (which could be used from the abstract)